### PR TITLE
changes for use Font(for cell,col[dbgrid]) and another changes.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 .hgtags
 lib/
 *.bak
+*.dcu
+*.~pas

--- a/source/kdbgrids.pas
+++ b/source/kdbgrids.pas
@@ -301,6 +301,11 @@ type
     { Extends TKCustomGrid behavior. Does not allow to edit if data set is writable
       or closed etc. }
     function EditorCreate(ACol, ARow: Integer): TWinControl; override;
+    { functions for get name class (Cell,Painter,Col,Row) }
+    function GetCellClass: TKGridCellClass; override;
+    function GetCellPainterClass: TKGridCellPainterClass; override;
+    function GetColClass: TKGridColClass; override;
+    function GetColorsClass:TKGridColorsClass; override;
     { Obtains field index associated with given column index, either according to fieldname or by another method. }
     function GetFieldIndex(AColIndex: Integer): Integer; virtual;
     { Returns row where column titles should be shown, limited to current fixed row count. }
@@ -732,9 +737,9 @@ var
   ACol, ARow: Integer;
 begin
   inherited;
-  if (Grid is TKDBGrid) and not Grid.Flag(cGF_EditorUpdating or cGF_DBDataUpdating)
+  if (Grid is TKCustomDBGrid) and not Grid.Flag(cGF_EditorUpdating or cGF_DBDataUpdating)
     and FindCell(ACol, ARow) then
-    TKDBGrid(Grid).BeforeCellUpdate(ACol, ARow);
+    TKCustomDBGrid(Grid).BeforeCellUpdate(ACol, ARow);
 end;
 
 function TKDBGridCell.CreateImageByType(const Header: TKImageHeaderString): TGraphic;
@@ -1080,17 +1085,10 @@ begin
   inherited;
   FActiveRecord := -1;
   FDBOptions := cDBOptionsDef;
-  FColors.Free;
-  FColors := TKDBGridColors.Create(Self);
   FDataBufferGrow := cDataBufferGrowDef;
   FOldColumnCount := -1;
   FOldFieldCount := -1;
   FTitleRow := cTitleRowDef;
-  CellClass := TKDBGridCell;
-  RealizeCellClass;
-  CellPainterClass := TKDBGridCellPainter;
-  ColClass := TKDBGridCol;
-  RealizeColClass;
 end;
 
 destructor TKCustomDBGrid.Destroy;
@@ -1788,7 +1786,7 @@ begin
   end;
 end;
 
-procedure TKCustomDBGrid.CMParentFontChanged(var Message: TMessage);
+procedure TKCustomDBGrid.CMFontChanged(var Message: TMessage);
 var i:integer;
 begin
   inherited;
@@ -1802,6 +1800,25 @@ begin
       end;
     Invalidate;
   end;
+end;
+function TKCustomDBGrid.GetCellClass: TKGridCellClass;
+begin
+  Result:= TKDBGridCell;
+end;
+
+function TKCustomDBGrid.GetCellPainterClass: TKGridCellPainterClass;
+begin
+  Result:= TKDBGridCellPainter;
+end;
+
+function TKCustomDBGrid.GetColClass: TKGridColClass;
+begin
+  Result:=TKDBGridCol;
+end;
+
+function TKCustomDBGrid.GetColorsClass: TKGridColorsClass;
+begin
+  Result:=TKDBGridColors;
 end;
 
 procedure TKCustomDBGrid.TopLeftChanged;

--- a/source/kdbgrids.pas
+++ b/source/kdbgrids.pas
@@ -281,7 +281,7 @@ type
     procedure SetDataSource(Value: TDataSource);
     procedure SetDBOptions(const Value: TKDBGridOptions);
     procedure SetTitleRow(const Value: Integer);
-    procedure CMParentFontChanged(var Message: TMessage); message CM_PARENTFONTCHANGED;
+    procedure CMFontChanged(var Message: TMessage); message CM_FONTCHANGED;
   protected
     { This field represents the internal data link. }
     FDataLink: TKDBGridDataLink;

--- a/source/kdbgrids.pas
+++ b/source/kdbgrids.pas
@@ -203,6 +203,7 @@ type
     procedure SetVertAlign(const Value: TKVAlign);
     procedure SetHorzPadding(const Value: Integer);
     procedure SetVertPadding(const Value: Integer);
+    procedure DBGridInvalidate;
   public
     { Creates the instance. Do not create custom instances. All necessary
       TKDBGridCol instances are created automatically by TKCustomDBGrid. }
@@ -338,6 +339,9 @@ type
     { Extends TKCustomGrid Behavior. Updates the grid if control size has
       been changed. }
     procedure UpdateSize; override;
+    { function for initiation font, brush and another property column from grid }
+    procedure InitialAxisParams(Item: TCollectionItem; Action: TCollectionNotification); override;
+
   public
     { Creates the instance. Assigns default values to properties, allocates
       default column, row and cell data, constucts a data link. }
@@ -934,8 +938,7 @@ end;
 procedure TKDBGridCol.SetBrush(const Value: TBrush);
 begin
   FBrush.Assign(Value);
-  if Grid is TKDBGrid then
-    TKDBGrid(Grid).Invalidate;
+  DBGridInvalidate;
 end;
 
 procedure TKDBGridCol.SetFieldName(const Value: TKString);
@@ -943,16 +946,15 @@ begin
   if Value <> FFieldName then
   begin
     FFieldName := Value;
-    if Grid is TKDBGrid then
-      TKDBGrid(Grid).DataChanged;
+    if Grid is TKCustomDBGrid then
+      TKCustomDBGrid(Grid).DataChanged;
   end;
 end;
 
 procedure TKDBGridCol.SetFont(const Value: TFont);
 begin
   FFont.Assign(Value);
-  if Grid is TKDBGrid then
-    TKDBGrid(Grid).Invalidate;
+  DBGridInvalidate;
 end;
 
 procedure TKDBGridCol.SetHorzAlign(const Value: TKHAlign);
@@ -960,8 +962,7 @@ begin
   if Value <> FHorzAlign then
   begin
     FHorzAlign := Value;
-    if Grid is TKDBGrid then
-      TKDBGrid(Grid).Invalidate;
+    DBGridInvalidate;
   end;
 end;
 
@@ -970,8 +971,7 @@ begin
   if Value <> FHorzPadding then
   begin
     FHorzPadding := Value;
-    if Grid is TKDBGrid then
-      TKDBGrid(Grid).Invalidate;
+    DBGridInvalidate;
   end;
 end;
 
@@ -980,14 +980,15 @@ begin
   if Value <> FTitle then
   begin
     FTitle := Value;
-    if Grid is TKDBGrid then
-      TKDBGrid(Grid).DataChanged;
+    if Grid is TKCustomDBGrid then
+      TKCustomDBGrid(Grid).DataChanged;
   end;
 end;
 
 procedure TKDBGridCol.SetTitleFont(const Value: TFont);
 begin
-  FTitleFont := Value;
+  FTitleFont.Assign(Value);
+  DBGridInvalidate;
 end;
 
 procedure TKDBGridCol.SetVertAlign(const Value: TKVAlign);
@@ -995,8 +996,7 @@ begin
   if Value <> FVertAlign then
   begin
     FVertAlign := Value;
-    if Grid is TKDBGrid then
-      TKDBGrid(Grid).Invalidate;
+    DBGridInvalidate;
   end;
 end;
 
@@ -1005,9 +1005,14 @@ begin
   if Value <> FVertPadding then
   begin
     FVertPadding := Value;
-    if Grid is TKDBGrid then
-      TKDBGrid(Grid).Invalidate;
+    DBGridInvalidate;
   end;
+end;
+
+procedure TKDBGridCol.DBGridInvalidate;
+begin
+  if Grid is TKCustomDBGrid then
+    TKCustomDBGrid(Grid).Invalidate;
 end;
 
 { TKDBGridCellPainter }
@@ -1790,16 +1795,27 @@ procedure TKCustomDBGrid.CMFontChanged(var Message: TMessage);
 var i:integer;
 begin
   inherited;
-  if ParentFont then
-  begin
     for i:=0 to Columns.Count -1 do
       if Columns.Items[i] is TKDBGridCol then
+      with (Columns.Items[i] as TKDBGridCol) do
       begin
-        (Columns.Items[i] as TKDBGridCol).Font.Assign(Font);
-        (Columns.Items[i] as TKDBGridCol).TitleFont.Assign(Font);
+        Font.Assign(Self.Font);
+        TitleFont.Assign(Self.Font);
       end;
     Invalidate;
   end;
+
+procedure TKCustomDBGrid.InitialAxisParams(Item: TCollectionItem; Action: TCollectionNotification);
+begin
+  inherited;
+  if (Action = cnAdded) and (Item is TKDBGridCol) then
+    with (Item as TKDBGridCol) do
+    begin
+      Font.Assign(Self.Font);
+      TitleFont.Assign(Self.Font);
+      Brush.Assign(Self.Brush);
+      // may be anothers assign ?
+    end;
 end;
 function TKCustomDBGrid.GetCellClass: TKGridCellClass;
 begin

--- a/source/kedits.pas
+++ b/source/kedits.pas
@@ -810,8 +810,8 @@ function TKNumberValue.GetIVal: Int64;
 const
   cMaxInt64F =  9.223372036854775807E+18;
   cMinInt64F = -9.223372036854775808E+18;
-  cMaxInt64 =  9223372036854775807;
-  cMinInt64 = -9223372036854775808;
+  cMaxInt64:Int64 = Int64(9223372036854775807);
+  cMinInt64:Int64 = -9223372036854775807 - 1 ;
 begin
   if FHasInt then
     Result := FIVal
@@ -841,8 +841,8 @@ function TKNumberValue.GetUIVal: UInt64;
 const
   cMaxUInt64F = 1.8446744073709551615E+19;
   cMinUInt64F =                     0E+01;
-  cMaxUInt64 = 18446744073709551615;
-  cMinUInt64 =                    0;
+  cMaxUInt64:Int64 = $FFFFFFFFFFFFFFFF; //18446744073709551615; // bug in d7
+  cMinUInt64:Int64 =                    0;
 begin
   if FHasInt then
     Result := UInt64(FIVal)

--- a/source/kfunctions.pas
+++ b/source/kfunctions.pas
@@ -35,7 +35,7 @@ uses
 {$ELSE}
   Windows, Messages,
 {$ENDIF}
-  Classes, Contnrs, SysUtils;
+  Classes, Contnrs, SysUtils, Graphics;
 
 const
   { Carriage return character. }

--- a/source/kfunctions.pas
+++ b/source/kfunctions.pas
@@ -828,6 +828,9 @@ function InsertSpacesToDigits(const Source: AnsiString): AnsiString;
   Example: Value = $A18D, Digit = $C, Pos = 3: Result = $AC8D }
 function ReplaceDigit(Value, Digit, Pos: Integer): Integer;
 
+{ Find property 'font' in Obj and get (if found) it }
+function GetFontFromTObject(const Obj:TObject; out Font:TFont ):boolean;
+
 implementation
 
 uses
@@ -2858,6 +2861,24 @@ begin
     O := O * cHexBase;
   Mask := cHexBase - 1;
   Result := (((Value div O) and not Mask) + (Digit and Mask)) * O + Value mod O;
+end;
+
+function GetFontFromTObject(const Obj:TObject; out Font:TFont ):boolean;
+Var
+  PInfo: PPropInfo;
+
+begin
+  Result:=false;
+  PInfo := GetPropInfo( Obj.ClassInfo, 'font' );
+  if PInfo <> Nil then
+  begin
+    If (PInfo^.Proptype^.Kind = tkClass) and
+      GetTypeData(PInfo^.Proptype^)^.ClassType.InheritsFrom(TFont) then
+    begin
+      Font := TFont(GetOrdProp( Obj, PInfo ));
+      Result:=true;
+    end
+  end;
 end;
 
 end.

--- a/source/kgrids.pas
+++ b/source/kgrids.pas
@@ -11681,38 +11681,6 @@ begin
   end;
 end;
 
-procedure TKCustomGrid.RealizeCellClass;
-var
-  I, J: Integer;
-  Cell, TmpCell: TKGridCell;
-  UpdateNeeded: Boolean;
-begin
-  if Assigned(FCells) then
-  begin
-    UpdateNeeded := False;
-    for I := 0 to FColCount - 1 do
-      for J := 0 to FRowCount - 1 do
-      begin
-        Cell := FCells[J, I];
-        if (Cell <> nil) then
-        begin
-          TmpCell := CellClass.Create(Self);
-          FlagSet(cGF_GridUpdates);
-          try
-            TmpCell.Assign(Cell); // copy known properties
-            Cell.Free;
-            FCells[J, I] := TmpCell;
-          finally
-            FlagClear(cGF_GridUpdates);
-          end;
-          UpdateNeeded := True;
-        end;
-      end;
-    if UpdateNeeded then
-      Invalidate;
-  end;
-end;
-
 procedure TKCustomGrid.ReadColWidths(Reader: TReader);
 var
   I, Tmp: Integer;

--- a/source/kgrids.pas
+++ b/source/kgrids.pas
@@ -2027,6 +2027,8 @@ type
     @link(TKCustomGrid.CellPainterClass) property. }
   TKGridCellPainterClass = class of TKGridCellPainter;
 
+  TKGridColorsClass = class of TKGridColors;
+
   { @abstract(Container for all colors used by @link(TKCustomGrid) class)
     This container allows to group many colors into one item in object inspector.
     Colors are accessible via published properties or several public Color*
@@ -2106,10 +2108,7 @@ type
   {$IFDEF FPC}
     FFlat: Boolean;
   {$ENDIF}
-    FCellClass: TKGridCellClass;
     FCellPainter: TKGridCellPainter;
-    FCellPainterClass: TKGridCellPainterClass;
-    FColClass: TKGridColClass;
     FColCount: Integer;
     FDefaultColWidth: Integer;
     FDefaultRowHeight: Integer;
@@ -2128,7 +2127,6 @@ type
     FMoveDirection: TKGridMoveDirection;
     FOptions: TKGridOptions;
     FOptionsEx: TKGridOptionsEx;
-    FRowClass: TKGridRowClass;
     FRowCount: Integer;
     FRangeSelectStyle: TKGridRangeSelectStyle;
     FScrollBars: TScrollStyle;
@@ -2232,7 +2230,6 @@ type
     procedure SetFlat(Value: Boolean);
   {$ENDIF}
     procedure SetCell(ACol, ARow: Integer; Value: TKGridCell);
-    procedure SetCellPainterClass(Value: TKGridCellPainterClass);
     procedure SetCells(ACol, ARow: Integer; const Text: KFunctions.TKString);
     procedure SetCellSpan(ACol, ARow: Integer; Value: TKGridCellSpan);
     procedure SetCol(Value: Integer);
@@ -2518,6 +2515,14 @@ type
     function GetDefaultRowHeight: Integer; virtual;
     { Returns bounding rectangle where dragged column or row should appear. }
     function GetDragRect(Info: TKGridAxisInfoBoth; out DragRect: TRect): Boolean; virtual;
+
+    { functions for get name class (Cell,Painter,Col,Row }
+    function GetCellClass: TKGridCellClass; virtual;
+    function GetCellPainterClass: TKGridCellPainterClass; virtual;
+    function GetColClass: TKGridColClass; virtual;
+    function GetRowClass: TKGridRowClass; virtual;
+    function GetColorsClass: TKGridColorsClass; virtual;
+
     { Returns the combination of invisible cells that must be taken into account
       for the state indicated by GridState.  }
     function GridStateToInvisibleCells: TKGridInvisibleCells;
@@ -3099,19 +3104,7 @@ type
       ensure that all the cells in the grid contain instances of CellClass or those
       inherited from CellClass. All possible cell class properties are copied by
       the @link(TKGridCell.Assign) method. }
-    procedure RealizeCellClass; virtual;
-    { Forces the column class specified by @link(TKCustomGrid.ColClass) to replace
-      all other column classes that do not inherit from it. Call this method to
-      ensure that the entire horizontal grid axis contains instances of ColClass
-      or those inherited from ColClass. All possible column class properties are
-      copied by the @link(TKGridAxisItem.Assign) method. }
-    procedure RealizeColClass; virtual;
-    { Forces the row class specified by @link(TKCustomGrid.RowClass) to replace
-      all other row classes that do not inherit from it. Call this method to
-      ensure that the entire vertical grid axis contains instances of RowClass
-      or those inherited from RowClass. All possible row class properties are
-      copied by the @link(TKGridAxisItem.Assign) method. }
-    procedure RealizeRowClass; virtual;
+
     { Determines if a row specified by ARow can be selected,
       i.e. lies in non-fixed area. }
     function RowSelectable(ARow: Integer): Boolean; virtual;
@@ -3189,12 +3182,12 @@ type
     property Cell[ACol, ARow: Integer]: TKGridCell read GetCell write SetCell;
     { Cell class used to create new cell instances. Cell instances are always
       created on demand. }
-    property CellClass: TKGridCellClass read FCellClass write FCellClass;
+    property CellClass: TKGridCellClass read GetCellClass;
     { Gains access to the active cell painter. }
     property CellPainter: TKGridCellPainter read FCellPainter;
     { Specifies the cell painter class used to create new @link(TKCustomGrid.CellPainter).
       The new cell painter instance will be created immediately. }
-    property CellPainterClass: TKGridCellPainterClass read FCellPainterClass write SetCellPainterClass;
+    property CellPainterClass: TKGridCellPainterClass read GetCellPainterClass;
     { Gains simplified access to the probably most used property of an textual
       cell instance. If the cell instance at the position specified by ACol and ARow
       does not inherit from a textual cell class @link(TKGridTextCell), it will be
@@ -3211,7 +3204,7 @@ type
     property Col: Integer read FSelection.Col1 write SetCol;
     { Column class used to create new column instances. Column instances are always
       created when @link(TKCustomGrid.ColCount) grows. }
-    property ColClass: TKGridColClass read FColClass write FColClass;
+    property ColClass: TKGridColClass read GetColClass;
     { Specifies the number of columns in the grid. Set ColCount to add or delete
       columns at the righthand side of the grid. The value of ColCount includes
       any fixed columns at the left of the grid as well as the scrollable columns
@@ -3368,7 +3361,7 @@ type
     property Row: Integer read FSelection.Row1 write SetRow;
     { Row class used to create new row instances. Row instances are always
       created when @link(TKCustomGrid.RowCount) grows. }
-    property RowClass: TKGridRowClass read FRowClass write FRowClass;
+    property RowClass: TKGridRowClass read GetRowClass;
     { Specifies the number of rows in the grid. Set RowCount to add or delete rows
       at the bottom of the grid. The value of RowCount includes any fixed rows at
       the top of the grid as well as the scrollable rows in the body of the grid. }
@@ -6353,13 +6346,10 @@ begin
   FCellHintTimer.Interval := cMouseCellHintTimeDef;
   FCellHintTimer.OnTimer := CellHintTimerHandler;
   FCells := nil;
-  FCellClass := TKGridTextCell;
-  FCellPainterClass := TKGridCellPainter;
-  FCellPainter := FCellPainterClass.Create(Self);
-  FColClass := TKGridCol;
+  FCellPainter := CellPainterClass.Create(Self);
   FColCount := cInvalidIndex;
-  FCols := TKGridAxisItems.Create(Self, FColClass);
-  FColors := TKGridColors.Create(Self);
+  FCols := TKGridAxisItems.Create(Self, ColClass);
+  FColors := GetColorsClass.Create(Self);
   FDefaultColWidth := cDefaultColWidthDef;
   FDefaultRowHeight := GetDefaultRowHeight;
   FDisabledDrawStyle := cDisabledDrawStyleDef;
@@ -6396,9 +6386,8 @@ begin
   FOptions := cOptionsDef;
   FOptionsEx := cOptionsExDef;
   FRangeSelectStyle := cRangeSelectStyleDef;
-  FRowClass := TKGridRow;
   FRowCount := cInvalidIndex;
-  FRows := TKGridAxisItems.Create(Self, FRowClass);
+  FRows := TKGridAxisItems.Create(Self, RowClass);
   FScrollBars := cScrollBarsDef;
   FScrollModeHorz := cScrollModeDef;
   FScrollModeVert := cScrollModeDef;
@@ -8339,6 +8328,31 @@ begin
   end;
 end;
 
+function TKCustomGrid.GetCellClass: TKGridCellClass;
+begin
+  Result:=TKGridTextCell;
+end;
+
+function TKCustomGrid.GetCellPainterClass: TKGridCellPainterClass;
+begin
+  Result:=TKGridCellPainter;
+end;
+
+function TKCustomGrid.GetColClass: TKGridColClass;
+begin
+  Result:=TKGridCol;
+end;
+
+function TKCustomGrid.GetRowClass: TKGridRowClass;
+begin
+  Result:=TKGridRow;
+end;
+
+function TKCustomGrid.GetColorsClass: TKGridColorsClass;
+begin
+  Result:=TKGridColors;
+end;
+
 function TKCustomGrid.GetDrawState(ACol, ARow: Integer; AFocused: Boolean): TKGridDrawState;
 var
   BaseCol, BaseRow: Integer;
@@ -9016,7 +9030,7 @@ end;
 function TKCustomGrid.InternalGetCell(ACol, ARow: Integer): TKGridCell;
 begin
   if FCells[ARow, ACol] = nil then
-    FCells[ARow, ACol] := FCellClass.Create(Self);
+    FCells[ARow, ACol] := CellClass.Create(Self);
   Result := FCells[ARow, ACol];
 end;
 
@@ -9607,8 +9621,8 @@ begin
   try
     if not (Cell is TKGridTextCell) then
     begin
-      if FCellClass.InheritsFrom(TKGridTextCell) then
-        Tmp := FCellClass.Create(Self)
+      if CellClass.InheritsFrom(TKGridTextCell) then
+        Tmp := CellClass.Create(Self)
       else
         Tmp := TKGridTextCell.Create(Self);
       Tmp.Assign(Cell);
@@ -11680,9 +11694,9 @@ begin
       for J := 0 to FRowCount - 1 do
       begin
         Cell := FCells[J, I];
-        if (Cell <> nil) and (Cell.ClassType <> FCellClass) then
+        if (Cell <> nil) then
         begin
-          TmpCell := FCellClass.Create(Self);
+          TmpCell := CellClass.Create(Self);
           FlagSet(cGF_GridUpdates);
           try
             TmpCell.Assign(Cell); // copy known properties
@@ -11696,46 +11710,6 @@ begin
       end;
     if UpdateNeeded then
       Invalidate;
-  end;
-end;
-
-procedure TKCustomGrid.RealizeColClass;
-var
-  NewItems, BkItems: TKGridAxisItems;
-begin
-  if FCols.ItemClass <> FColClass then
-  begin
-    FlagSet(cGF_GridUpdates);
-    try
-      NewItems := TKGridAxisItems.Create(Self, FColClass);
-      NewItems.Assign(FCols);
-      BKItems := FCols;
-      FCols := NewItems;
-      BKItems.Free;
-    finally
-      FlagClear(cGF_GridUpdates);
-    end;
-    UpdateAxes(True, cAll, False, cAll, []);
-  end;
-end;
-
-procedure TKCustomGrid.RealizeRowClass;
-var
-  NewItems, BkItems: TKGridAxisItems;
-begin
-  if FRows.ItemClass <> FRowClass then
-  begin
-    FlagSet(cGF_GridUpdates);
-    try
-      NewItems := TKGridAxisItems.Create(Self, FRowClass);
-      NewItems.Assign(FRows);
-      BKItems := FRows;
-      FRows := NewItems;
-      BKItems.Free;
-    finally
-      FlagClear(cGF_GridUpdates);
-    end;
-    UpdateAxes(False, cAll, True, cAll, []);
   end;
 end;
 
@@ -12229,16 +12203,6 @@ begin
     InternalSetCell(ACol, ARow, Value);
 end;
 
-procedure TKCustomGrid.SetCellPainterClass(Value: TKGridCellPainterClass);
-begin
-  if Value <> FCellPainterClass then
-  begin
-    FCellPainterClass := Value;
-    FCellPainter.Free;
-    FCellPainter := FCellPainterClass.Create(Self);
-  end;
-end;
-
 procedure TKCustomGrid.SetCells(ACol, ARow: Integer; const Text: KFunctions.TKString);
 begin
   if Assigned(FCells) and ColValid(ACol) and RowValid(ARow) then
@@ -12547,8 +12511,8 @@ begin
       Cell := InternalGetCell(ACol, ARow);
       if not (Cell is TKGridObjectCell) then
       begin
-        if FCellClass.InheritsFrom(TKGridObjectCell) then
-          Tmp := FCellClass.Create(Self)
+        if CellClass.InheritsFrom(TKGridObjectCell) then
+          Tmp := CellClass.Create(Self)
         else
           Tmp := TKGridObjectCell.Create(Self);
         Tmp.Assign(Cell);


### PR DESCRIPTION
Hi !
My patches for supports "Font" in any grid items(cell, col, etc).
Remove reassign from column based on TKCustomGrid to column based on TKCustomDBGrid as unused after my patches.

If you commit me changes - Please fixit manual documnets, and my English lang =). 

Trank You!